### PR TITLE
TimePicker: Set the selection range after scrolling up or down

### DIFF
--- a/packages/date-picker/src/basic/time-spinner.vue
+++ b/packages/date-picker/src/basic/time-spinner.vue
@@ -283,6 +283,7 @@
 
         this.modifyDateField(label, now);
         this.adjustSpinner(label, now);
+        this.$nextTick(() => this.emitSelectRange(this.currentScrollbar));
       },
       amPm(hour) {
         let shouldShowAmPm = this.amPmMode.toLowerCase() === 'a';


### PR DESCRIPTION
After scrolling up or down in the time picker's text box, the selected text is lost and the cursor goes to the end of the input (though scrolling continues to work). This fixes the problem by calling emitSelectRange at the end of the scrollDown method.

Element PR: https://github.com/ElemeFE/element/pull/16868