### PR TITLE
TimePicker: Fix bugs with selection and display with regard to format options

### DIFF
--- a/packages/date-picker/src/basic/time-spinner.vue
+++ b/packages/date-picker/src/basic/time-spinner.vue
@@ -161,6 +161,7 @@
         type: String,
         default: '' // 'a': am/pm; 'A': AM/PM
       },
+      twelveHourClock: Boolean,
       zeroPadHour: Boolean
     },
 
@@ -270,7 +271,7 @@
       formatListItem(type, value) {
         let text;
         if (type === 'hours') {
-          text = ('0' + (this.amPmMode ? (value % 12 || 12) : value)).slice(-2);
+          text = ('0' + (this.twelveHourClock ? (value % 12 || 12) : value)).slice(-2);
           if (!this.zeroPadHour) {
             text = text.replace(/^0/, '');
           }
@@ -287,7 +288,7 @@
       },
 
       emitSelectRange(type) {
-        const hoursLen = !this.zeroPadHour && (this.date.getHours() % 12 || 12) < 10 ? 1 : 2;
+        const hoursLen = !this.zeroPadHour && (this.twelveHourClock ? (this.date.getHours() % 12 || 12) : this.date.getHours()) < 10 ? 1 : 2;
         const secondsOffset = this.showSeconds ? 3 : 0;
         if (type === 'hours') {
           this.$emit('select-range', 0, hoursLen);

--- a/packages/date-picker/src/panel/time-range.vue
+++ b/packages/date-picker/src/panel/time-range.vue
@@ -17,6 +17,7 @@
               :show-seconds="showSeconds"
               :show-am-pm="showAmPm"
               :am-pm-mode="amPmMode"
+              :twelve-hour-clock="twelveHourClock"
               :zero-pad-hour="zeroPadHour"
               @change="handleMinChange"
               :arrow-control="arrowControl"
@@ -35,6 +36,8 @@
               :show-seconds="showSeconds"
               :show-am-pm="showAmPm"
               :am-pm-mode="amPmMode"
+              :twelve-hour-clock="twelveHourClock"
+              :zero-pad-hour="zeroPadHour"
               @change="handleMaxChange"
               :arrow-control="arrowControl"
               @select-range="setMaxSelectionRange"
@@ -118,6 +121,10 @@
         if ((this.format || '').indexOf('A') !== -1) return 'A';
         if ((this.format || '').indexOf('a') !== -1) return 'a';
         return '';
+      },
+
+      twelveHourClock() {
+        return (this.format || '').indexOf('hh') !== -1 || (this.format || '').indexOf('h') !== -1;
       },
 
       zeroPadHour() {
@@ -223,10 +230,10 @@
       changeSelectionRange(step) {
         const secondsOffset = this.showSeconds ? 3 : 0;
 
-        const minHoursLen = !this.zeroPadHour && this.minDate && (this.minDate.getHours() % 12 || 12) < 10 ? 1 : 2;
+        const minHoursLen = !this.zeroPadHour && this.minDate && (this.twelveHourClock ? (this.minDate.getHours() % 12 || 12) : this.minDate.getHours()) < 10 ? 1 : 2;
         const list1 = [0, 3 - (2 - minHoursLen)].concat(this.showSeconds ? [6 - (2 - minHoursLen)] : []).concat(this.showAmPm ? [6 + secondsOffset - (2 - minHoursLen)] : []);
 
-        const maxHoursLen = !this.zeroPadHour && this.maxDate && (this.maxDate.getHours() % 12 || 12) < 10 ? 1 : 2;
+        const maxHoursLen = !this.zeroPadHour && this.maxDate && (this.twelveHourClock ? (this.maxDate.getHours() % 12 || 12) : this.maxDate.getHours()) < 10 ? 1 : 2;
         const list2 = [this.offset, this.offset + 3 - (2 - maxHoursLen)].concat(this.showSeconds ? [this.offset + 6 - (2 - maxHoursLen)] : []).concat(this.showAmPm ? [this.offset + 6 + secondsOffset - (2 - maxHoursLen)] : []);
 
         const list = list1.concat(list2);

--- a/packages/date-picker/src/panel/time.vue
+++ b/packages/date-picker/src/panel/time.vue
@@ -12,6 +12,7 @@
           :show-seconds="showSeconds"
           :show-am-pm="showAmPm"
           :am-pm-mode="amPmMode"
+          :twelve-hour-clock="twelveHourClock"
           :zero-pad-hour="zeroPadHour"
           @select-range="setSelectionRange"
           :date="date">
@@ -123,6 +124,9 @@
         if ((this.format || '').indexOf('a') !== -1) return 'a';
         return '';
       },
+      twelveHourClock() {
+        return (this.format || '').indexOf('hh') !== -1 || (this.format || '').indexOf('h') !== -1;
+      },
       zeroPadHour() {
         return (this.format || '').indexOf('HH') !== -1 || (this.format || '').indexOf('hh') !== -1;
       }
@@ -185,7 +189,7 @@
       },
 
       changeSelectionRange(step) {
-        const hoursLen = !this.zeroPadHour && (this.date.getHours() % 12 || 12) < 10 ? 1 : 2;
+        const hoursLen = !this.zeroPadHour && (this.twelveHourClock ? (this.date.getHours() % 12 || 12) : this.date.getHours()) < 10 ? 1 : 2;
         const secondsOffset = this.showSeconds ? 3 : 0;
         const list = [0, (3 - (2 - hoursLen))].concat(this.showSeconds ? [(6 - (2 - hoursLen))] : []).concat(this.showAmPm ? [(6 + secondsOffset - (2 - hoursLen))] : []);
         const mapping = ['hours', 'minutes'].concat(this.showSeconds ? ['seconds'] : []).concat(this.showAmPm ? ['amPm'] : []);

--- a/test/unit/specs/time-picker.spec.js
+++ b/test/unit/specs/time-picker.spec.js
@@ -98,6 +98,52 @@ describe('TimePicker', () => {
 
   it('selection range with 1 digit hour', async() => {
     vm = createVue({
+      template: '<el-time-picker ref="compo" format="H:mm:ss" v-model="value"></el-time-picker>',
+      data() {
+        return {
+          value: new Date(1970, 0, 1, 13, 0, 0, 0)
+        };
+      }
+    }, true);
+    const timePicker = vm.$refs.compo;
+    const input = timePicker.$el.querySelector('input');
+    input.blur();
+    input.focus();
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('0,2');
+    triggerKeyDown(input, 39);
+    triggerEvent(input, 'keyup');
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('3,5');
+    triggerKeyDown(input, 39);
+    triggerEvent(input, 'keyup');
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('6,8');
+  });
+
+  it('selection range with 1 digit hour and 12 hour mode', async() => {
+    vm = createVue({
+      template: '<el-time-picker ref="compo" format="h:mm" v-model="value"></el-time-picker>',
+      data() {
+        return {
+          value: new Date(1970, 0, 1, 13, 0, 0, 0)
+        };
+      }
+    }, true);
+    const timePicker = vm.$refs.compo;
+    const input = timePicker.$el.querySelector('input');
+    input.blur();
+    input.focus();
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('0,1');
+    triggerKeyDown(input, 39);
+    triggerEvent(input, 'keyup');
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('2,4');
+  });
+
+  it('selection range with AM/PM', async() => {
+    vm = createVue({
       template: '<el-time-picker ref="compo" format="h:mm A" toggle-am-pm v-model="value"></el-time-picker>',
       data() {
         return {


### PR DESCRIPTION
- Selection range for hour should mod 12 if a twelve hour clock is used
- Hour displayed in spinner should mod 12 if a twelve hour clock is used, not based on AM/PM (although correlated)
- Pass missing zero-pad-hours prop for range max selector