### PR TITLE
Add support for localizing am/pm

### DIFF
--- a/packages/date-picker/src/basic/time-spinner.vue
+++ b/packages/date-picker/src/basic/time-spinner.vue
@@ -134,7 +134,7 @@
 </template>
 
 <script type="text/babel">
-  import { getRangeHours, getRangeMinutes, modifyTime } from 'element-ui/src/utils/date-util';
+  import { getRangeHours, getRangeMinutes, modifyTime, getI18nSettings } from 'element-ui/src/utils/date-util';
   import ElScrollbar from 'element-ui/packages/scrollbar';
   import RepeatClick from 'element-ui/src/directives/repeat-click';
 
@@ -390,8 +390,13 @@
         let shouldShowAmPm = this.amPmMode.toLowerCase() === 'a';
         if (!shouldShowAmPm) return '';
         let isCapital = this.amPmMode === 'A';
-        let content = (hour < 12) ? 'am' : 'pm';
-        if (isCapital) content = content.toUpperCase();
+        const i18n = getI18nSettings();
+        let content = (hour < 12) ? i18n.amPm[0] || 'am' : i18n.amPm[1] || 'pm';
+        if (isCapital) {
+          content = content.toUpperCase();
+        } else {
+          content = content.toLowerCase();
+        }
         return prefix + content;
       },
       typeItemHeight(type) {

--- a/src/locale/index.js
+++ b/src/locale/index.js
@@ -30,7 +30,7 @@ export const t = function(path, options) {
   for (let i = 0, j = array.length; i < j; i++) {
     const property = array[i];
     value = current[property];
-    if (i === j - 1) return format(value, options);
+    if (i === j - 1) return value ? format(value, options) : '';
     if (!value) return '';
     current = value;
   }

--- a/src/utils/date-util.js
+++ b/src/utils/date-util.js
@@ -18,7 +18,7 @@ export const getI18nSettings = () => {
     dayNames: weeks.map(week => t(`el.datepicker.weeks.${ week }`)),
     monthNamesShort: months.map(month => t(`el.datepicker.months.${ month }`)),
     monthNames: months.map((month, index) => t(`el.datepicker.month${ index + 1 }`)),
-    amPm: ['am', 'pm']
+    amPm: ['am', 'pm'].map(amOrPm => t(`el.datepicker.${ amOrPm }`) || amOrPm)
   };
 };
 


### PR DESCRIPTION
- `locale/index.js`: Prevent error when the final resource property doesn't exist (was already doing this for prior steps, see line 34 below)
- `date-util.js`: Add support for localizing am/pm (the "fecha" library already supports this)
- `time-spinner.vue`: Use localized am/pm in time spinner