### PR TITLE
DatePicker: style current date using explicity set 'date' field

### DIFF
--- a/packages/date-picker/src/basic/date-table.vue
+++ b/packages/date-picker/src/basic/date-table.vue
@@ -267,7 +267,7 @@
           classes.push('default');
         }
 
-        if (selectionMode === 'day' && (cell.type === 'normal' || cell.type === 'today') && this.cellMatchesDate(cell, this.value)) {
+        if (selectionMode === 'day' && (cell.type === 'normal' || cell.type === 'today') && this.cellMatchesDate(cell, this.date || this.value)) {
           classes.push('current');
         }
 


### PR DESCRIPTION
Currently, the date table (the grid of dates shown in the picker) styles the "current" date based on the `:value` prop. However, as you move around the date picker using the arrow keys, the date picker internally sets the `:date` prop to the selected value, but the `:value` prop only gets updated as a result of the typical component data flow of `@input` event out then `:value` prop back in. So, since we don't update the model on `@input` but wait until `@change`, the `value` prop hasn't been updated yet. This change gives priority to the `:date` prop so that the keyboard commands from the user are reflected in the picker as expected.

**Caveats:**
The `:date` prop is updated when the `:value` prop changes, but it appears that there is an edge case where it will be assigned the default value if the `:value` prop has no value. I'm not sure why, but it may be in order to anchor the initial actions of the user, for example. We're not using the `:default-value` prop, so it shouldn't affect us. And I'm not sure if there's actually a problem with it being visually indicated as the "current" date in that case anyway.