### PR TITLE
Switch: Avoid error if destroyed when toggled

### DIFF
--- a/packages/switch/src/component.vue
+++ b/packages/switch/src/component.vue
@@ -132,6 +132,11 @@
         this.$emit('input', val);
         this.$emit('change', val);
         this.$nextTick(() => {
+          // Don't attempt to change the checkbox value if the component
+          // has been destroyed as a result of toggling the value
+          if (this._isDestroyed) {
+            return;
+          }
           // set input's checked property
           // in case parent refuses to change component's value
           this.$refs.input.checked = this.checked;


### PR DESCRIPTION
The scenario where I discovered this was where a Yes/No field in a table controlled conditional visibility of other fields in the table. If the table was in responsive section mode, and toggling the switch caused the fields to be hidden, the size of the columns could then be small enough to fit in table mode, which would cause the section to be destroyed and the table rendered. The `this.$refs.input.checked = this.checked;` line would cause the error "TypeError: Cannot set property 'checked' of undefined".

https://codepen.io/mattheyan/pen/KKPjNwx
