### PR TITLE
Only add height and not both height and minHeight to textareas.

### DIFF
--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -325,7 +325,7 @@
         const minRows = autosize.minRows;
         const maxRows = autosize.maxRows;
 
-        this.textareaCalcStyle = calcTextareaHeight(this.$refs.textarea, minRows, maxRows);
+        this.textareaCalcStyle = {height: calcTextareaHeight(this.$refs.textarea, minRows, maxRows).height};
       },
       setNativeInputValue() {
         const input = this.getInput();


### PR DESCRIPTION
This is the minimum amount of change to affect what I want, for table textareas. That is, They should have a height set but not a min-height so the min-height can be 100% of the table row (in case there are other extra tall cells in that row).