### PR TITLE
select: spacebar event to open popper

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -88,6 +88,7 @@
       @keydown.native.enter="handleEnterKey"
       @keydown.native.esc="handleEscapeKey"
       @keydown.native.tab="handleTabKey"
+      @keydown.native.space="handleSpaceKey"
       @paste.native="debouncedOnInputChange"
       @mouseenter.native="inputHovering = true"
       @mouseleave.native="inputHovering = false">
@@ -515,6 +516,15 @@
 
       handleTabKey(e) {
         this.visible = false;
+      },
+
+      handleSpaceKey(e) {
+        if (!this.visible) {
+          e.stopPropagation();
+          e.preventDefault();
+          this.visible = true;
+        }
+        return true;
       },
 
       scrollToOption(option) {

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -524,7 +524,6 @@
           e.preventDefault();
           this.visible = true;
         }
-        return true;
       },
 
       scrollToOption(option) {


### PR DESCRIPTION
Added space bar key event to Select element to allow the Select component to be opened with the space bar for keyboard accessibility. 

- Added check to disable the event when the component is filterable so the user can type spaces in the search