### PR TITLE
Enable min/max based disabling of dates

### DIFF
--- a/packages/date-picker/src/panel/date.vue
+++ b/packages/date-picker/src/panel/date.vue
@@ -646,7 +646,7 @@
           return true;
         } else if (this.minimum) {
           // If minimum is defined, ensure that the last day of the previous year is not before the minimum
-          let lastDayOfPrevYear = new Date(this.date.getFullYear() - 1, 11, 1);
+          let lastDayOfPrevYear = new Date(this.date.getFullYear() - 1, 11, 31);
           return lastDayOfPrevYear >= this.minimum;
         } else {
           return true;

--- a/packages/date-picker/src/panel/date.vue
+++ b/packages/date-picker/src/panel/date.vue
@@ -369,7 +369,7 @@
       changeToNow() {
         // NOTE: not a permanent solution
         //       consider disable "now" button in the future
-        if ((!this.disabledDate || !this.disabledDate(new Date())) && this.checkTimeWithinRange(new Date())) {
+        if (this.isValidValue(new Date())) {
           this.date = new Date();
           this.emit(this.date);
         }
@@ -445,7 +445,7 @@
         while (Math.abs(now - newDate.getTime()) <= year) {
           const map = mapping[mode];
           map.offset(newDate, map[keyCode]);
-          if (typeof this.disabledDate === 'function' && this.disabledDate(newDate)) {
+          if (!this.isValidDate(newDate)) {
             continue;
           }
           this.date = newDate;
@@ -468,7 +468,7 @@
       handleVisibleDateChange(value) {
         const date = parseDate(value, this.dateFormat);
         if (date) {
-          if (typeof this.disabledDate === 'function' && this.disabledDate(date)) {
+          if (!this.isValidDate(date)) {
             return;
           }
           this.date = modifyTime(date, this.date.getHours(), this.date.getMinutes(), this.date.getSeconds());
@@ -479,11 +479,15 @@
       },
 
       isValidValue(value) {
-        return value && !isNaN(value) && (
+        return this.isValidDate(value) && this.checkTimeWithinRange(value);
+      },
+
+      isValidDate(date) {
+        return date && !isNaN(date) && (
           typeof this.disabledDate === 'function'
-            ? !this.disabledDate(value)
+            ? !this.disabledDate(date)
             : true
-        ) && this.checkTimeWithinRange(value);
+        );
       },
 
       getDefaultValue() {

--- a/packages/date-picker/src/panel/date.vue
+++ b/packages/date-picker/src/panel/date.vue
@@ -342,7 +342,7 @@
             ? modifyDate(this.value, value.getFullYear(), value.getMonth(), value.getDate())
             : modifyWithTimeString(value, this.defaultTime);
           // change default time while out of selectableRange
-          if (!this.checkDateWithinRange(newDate)) {
+          if (!this.checkTimeWithinRange(newDate)) {
             newDate = modifyDate(this.selectableRange[0][0], value.getFullYear(), value.getMonth(), value.getDate());
           }
           this.date = newDate;
@@ -369,7 +369,7 @@
       changeToNow() {
         // NOTE: not a permanent solution
         //       consider disable "now" button in the future
-        if ((!this.disabledDate || !this.disabledDate(new Date())) && this.checkDateWithinRange(new Date())) {
+        if ((!this.disabledDate || !this.disabledDate(new Date())) && this.checkTimeWithinRange(new Date())) {
           this.date = new Date();
           this.emit(this.date);
         }
@@ -456,7 +456,7 @@
 
       handleVisibleTimeChange(value) {
         const time = parseDate(value, this.timeFormat);
-        if (time && this.checkDateWithinRange(time)) {
+        if (time && this.checkTimeWithinRange(time)) {
           this.date = modifyDate(time, this.year, this.month, this.monthDate);
           this.userInputTime = null;
           this.$refs.timepicker.value = this.date;
@@ -483,7 +483,7 @@
           typeof this.disabledDate === 'function'
             ? !this.disabledDate(value)
             : true
-        ) && this.checkDateWithinRange(value);
+        ) && this.checkTimeWithinRange(value);
       },
 
       getDefaultValue() {
@@ -492,7 +492,7 @@
         return this.defaultValue ? new Date(this.defaultValue) : new Date();
       },
 
-      checkDateWithinRange(date) {
+      checkTimeWithinRange(date) {
         return this.selectableRange.length > 0
           ? timeWithinRange(date, this.selectableRange, this.format || 'HH:mm:ss')
           : true;

--- a/packages/date-picker/src/panel/date.vue
+++ b/packages/date-picker/src/panel/date.vue
@@ -105,7 +105,7 @@
               :default-value="defaultValue ? new Date(defaultValue) : null"
               :date="date"
               :cell-class-name="cellClassName"
-              :disabled-date="disabledDate || dateOutOfRange">
+              :disabled-date="disabledDate || (minimum || maximum ? dateOutOfRange : '')">
             </date-table>
             <year-table
               v-show="currentView === 'year'"
@@ -113,7 +113,7 @@
               :value="value"
               :default-value="defaultValue ? new Date(defaultValue) : null"
               :date="date"
-              :disabled-date="disabledDate || dateOutOfRange">
+              :disabled-date="disabledDate || (minimum || maximum ? dateOutOfRange : '')">
             </year-table>
             <month-table
               v-show="currentView === 'month'"
@@ -121,7 +121,7 @@
               :value="value"
               :default-value="defaultValue ? new Date(defaultValue) : null"
               :date="date"
-              :disabled-date="disabledDate || dateOutOfRange">
+              :disabled-date="disabledDate || (minimum || maximum ? dateOutOfRange : '')">
             </month-table>
           </div>
         </div>

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -389,6 +389,8 @@ export default {
     rangeSeparator: {
       default: '-'
     },
+    minimum: Date,
+    maximum: Date,
     pickerOptions: {},
     unlinkPanels: Boolean,
     validateEvent: {
@@ -842,6 +844,17 @@ export default {
       this.picker.unlinkPanels = this.unlinkPanels;
       this.picker.arrowControl = this.arrowControl || this.timeArrowControl || false;
       this.picker.toggleAmPm = this.toggleAmPm || false;
+
+      this.picker.minimum = this.minimum || null;
+      this.$watch('minimum', (minimum) => {
+        this.picker.minimum = minimum || null;
+      });
+
+      this.picker.maximum = this.maximum || null;
+      this.$watch('maximum', (maximum) => {
+        this.picker.maximum = maximum || null;
+      });
+
       this.$watch('format', (format) => {
         this.picker.format = format;
       });

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -409,7 +409,9 @@ export default {
       showClose: false,
       userInput: null,
       valueOnOpen: null, // value when picker opens, used to determine whether to emit change
-      unwatchPickerOptions: null
+      unwatchPickerOptions: null,
+      unwatchPickerMin: null,
+      unwatchPickerMax: null
     };
   },
 
@@ -846,12 +848,12 @@ export default {
       this.picker.toggleAmPm = this.toggleAmPm || false;
 
       this.picker.minimum = this.minimum || null;
-      this.$watch('minimum', (minimum) => {
+      this.unwatchPickerMin = this.$watch('minimum', (minimum) => {
         this.picker.minimum = minimum || null;
       });
 
       this.picker.maximum = this.maximum || null;
-      this.$watch('maximum', (maximum) => {
+      this.unwatchPickerMax = this.$watch('maximum', (maximum) => {
         this.picker.maximum = maximum || null;
       });
 
@@ -915,6 +917,14 @@ export default {
         this.picker.$off();
         if (typeof this.unwatchPickerOptions === 'function') {
           this.unwatchPickerOptions();
+        }
+        if (typeof this.unwatchPickerMin === 'function') {
+          this.unwatchPickerMin();
+          this.unwatchPickerMin = null;
+        }
+        if (typeof this.unwatchPickerMax === 'function') {
+          this.unwatchPickerMax();
+          this.unwatchPickerMax = null;
         }
         this.picker.$el.parentNode.removeChild(this.picker.$el);
       }


### PR DESCRIPTION
The goal of this PR is to enable min/max based disabling of dates as an alternative to the `disabledDate` function, and also to leverage this to restrict navigation (prev month, next year, etc.) in the date picker.

Changes:
- Rename the existing `checkDateWithinRange` method in the `date` (panel) component to `checkTimeWithinRange`, to avoid confusion with the new `minimum` and `maximum` options, since its actually doing time comparison
- Refactor to reduce references to `disabledDate` and `checkTimeWithinRange` by leveraging `isValidValue` and `isValidDate` methods (this way the usage of `disabledDate` and the new `minimum` and `maximum` options wouldn't have to be replicated everywhere)
- Add `minimum` and `maximum` options to picker and use that in place of `disabledDates` if a function is not provided
- If no `disabledDates` function is provided, and min/max are, then prevent forward and backward navigation when the min or max is reached

Before:
`:disabled-date="(date) => date < minimum || date > maximum"`
![image](https://user-images.githubusercontent.com/300377/87162507-0733b900-c294-11ea-85bb-19d69d561e58.png)

After:
`:minimum="minimum" :maximum="maximum"`
![image](https://user-images.githubusercontent.com/300377/87162582-1fa3d380-c294-11ea-8618-0f113167407e.png)
