### PR TITLE
feat: tab key selects option and closes picker to mirror native select

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -62,7 +62,7 @@
         @keydown.enter.prevent="selectOption"
         @keydown.esc.stop.prevent="visible = false"
         @keydown.delete="deletePrevTag"
-        @keydown.tab="visible = false"
+        @keydown.tab="handleTabKey"
         @compositionstart="handleComposition"
         @compositionupdate="handleComposition"
         @compositionend="handleComposition"
@@ -540,6 +540,10 @@
       },
 
       handleTabKey(e) {
+        if (this.visible) {
+          e.preventDefault();
+        }
+        this.selectOption(e);
         this.visible = false;
       },
 


### PR DESCRIPTION
When the select dropdown is open, pressing the tab key should select the active option and close the dropdown, leaving the select field focused. This behavior mirrors how native selects work when pressing the tab key while the select is open.