### PR TITLE
Prevent iOS from being readonly

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -163,7 +163,7 @@
   import { addResizeListener, removeResizeListener } from 'element-ui/src/utils/resize-event';
   import { t } from 'element-ui/src/locale';
   import scrollIntoView from 'element-ui/src/utils/scroll-into-view';
-  import { getValueByPath, valueEquals, isIE, isEdge } from 'element-ui/src/utils/util';
+  import { getValueByPath, valueEquals, isIE, isEdge, isIOS } from 'element-ui/src/utils/util';
   import NavigationMixin from './navigation-mixin';
   import { isKorean } from 'element-ui/src/utils/shared';
 
@@ -196,7 +196,7 @@
       },
 
       readonly() {
-        return !this.filterable || this.multiple || (!isIE() && !isEdge() && !this.visible);
+        return !this.filterable || this.multiple || (!isIE() && !isEdge() && !isIOS() && this.visible);
       },
 
       showClose() {

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -126,6 +126,11 @@ export const isFirefox = function() {
   return !Vue.prototype.$isServer && !!window.navigator.userAgent.match(/firefox/i);
 };
 
+export const isIOS = function() {
+  // https://stackoverflow.com/a/58064481/2836695
+  return !Vue.prototype.$isServer && (/iPad|iPhone|iPod/.test(navigator.platform) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1));
+};
+
 export const autoprefixer = function(style) {
   if (typeof style !== 'object') return style;
   const rules = ['transform', 'transition', 'animation'];


### PR DESCRIPTION
The readonly attribute is causing the keyboard not to open in ios. I don't understand why that readonly attribute is ever necessary but this PR just keeps it from getting added on iOS.

https://cognitoforms.visualstudio.com/Cognito%20Forms/_workitems/edit/16397