### PR TITLE
Select: Add 'filterMatch' option to control filtering behavior

### DIFF
--- a/packages/select/src/option.vue
+++ b/packages/select/src/option.vue
@@ -139,7 +139,7 @@
 
       queryChange(query) {
         let queryExpr = escapeRegexpString(query);
-        if (this.select && this.select.filterMode === 'startsWith') {
+        if (this.select && this.select.filterMatch === 'beginning') {
           queryExpr = '^' + queryExpr;
         }
         this.visible = new RegExp(queryExpr, 'i').test(this.currentLabel) || this.created;

--- a/packages/select/src/option.vue
+++ b/packages/select/src/option.vue
@@ -138,7 +138,11 @@
       },
 
       queryChange(query) {
-        this.visible = new RegExp(escapeRegexpString(query), 'i').test(this.currentLabel) || this.created;
+        let queryExpr = escapeRegexpString(query);
+        if (this.select && this.select.filterMode === 'startsWith') {
+          queryExpr = '^' + queryExpr;
+        }
+        this.visible = new RegExp(queryExpr, 'i').test(this.currentLabel) || this.created;
         if (!this.visible) {
           this.select.filteredOptionsCount--;
         }

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -289,6 +289,10 @@
       disabled: Boolean,
       clearable: Boolean,
       filterable: Boolean,
+      filterMode: {
+        type: String,
+        default: 'contains'
+      },
       editable: Boolean,
       allowCreate: Boolean,
       loading: Boolean,

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -289,9 +289,9 @@
       disabled: Boolean,
       clearable: Boolean,
       filterable: Boolean,
-      filterMode: {
+      filterMatch: {
         type: String,
-        default: 'contains'
+        default: 'anywhere'
       },
       editable: Boolean,
       allowCreate: Boolean,

--- a/types/select.d.ts
+++ b/types/select.d.ts
@@ -45,8 +45,8 @@ export declare class ElSelect extends ElementUIComponent {
   /** Whether Select is filterable */
   filterable: boolean
 
-  /** Specify whether to match options that contain the filter ('contains'), or start with the filter ('startsWith') */
-  filterMode: string
+  /** Specify whether to match options that contain the filter ('anywhere'), or start with the filter ('beginning') */
+  filterMatch: string
 
   /** Whether creating new items is allowed. To use this, filterable must be true */
   allowCreate: boolean

--- a/types/select.d.ts
+++ b/types/select.d.ts
@@ -45,6 +45,9 @@ export declare class ElSelect extends ElementUIComponent {
   /** Whether Select is filterable */
   filterable: boolean
 
+  /** Specify whether to match options that contain the filter ('contains'), or start with the filter ('startsWith') */
+  filterMode: string
+
   /** Whether creating new items is allowed. To use this, filterable must be true */
   allowCreate: boolean
 


### PR DESCRIPTION
We have the requirement that when you filter some select fields, it should only match text that *starts with* the typed text. A good example of this is state and country fields. If you type "al", you would expect it to match "Alabama" and "Alaska", but not "California".

I found that the element select has an option for a filter method, which is simply passed the filter text. Technically we could use this to satisfy the requirement, but it would mean re-implementing the filtering logic, and doing the actual filtering differently than what element does internally (i.e. we'd have to filter out the options that are passed to the element component as props). Since I wasn't sure what the side-effects of doing that might be, and this approach is much simpler and avoids duplication, I decided to go with the option of updating element to support a filter mode ("contains" or "startsWith").