### PR TITLE
DatePicker: Date selection/highlighting fixes

### DIFF
--- a/packages/date-picker/src/basic/date-table.vue
+++ b/packages/date-picker/src/basic/date-table.vue
@@ -267,7 +267,7 @@
           classes.push('default');
         }
 
-        if (selectionMode === 'day' && (cell.type === 'normal' || cell.type === 'today') && this.cellMatchesDate(cell, this.date || this.value)) {
+        if (selectionMode === 'day' && (cell.type === 'normal' || cell.type === 'today') && this.cellMatchesDate(cell, this.value)) {
           classes.push('current');
         }
 

--- a/packages/date-picker/src/panel/date.vue
+++ b/packages/date-picker/src/panel/date.vue
@@ -462,9 +462,6 @@
             event.stopPropagation();
             event.preventDefault();
           }
-          if (keyCode === 13 && this.userInputDate === null && this.userInputTime === null) { // Enter
-            this.emit(this.date, false);
-          }
         }
       },
 


### PR DESCRIPTION
This PR addresses inconsistencies in the way that "selected" dates are highlighted in the date picker calendar. The component's internal `date` property is used to drive a lot of behavior, but it doesn't always correspond to the component's "persisted" value (i.e. the `value` prop), and this can lead to some misleading styling. For example, when the picker is opened with no value, the default (ex: current date) is flagged as "selected", even though it isn't actually the current value, and if the picker is closed it won't be persisted. Also, in that case, when navigating to previous/next months and years, another date is marked as "selected", which is also not the persisted value. To address this, don't take into account the `date` data property when adding the class for the selected date.

Related: Don't select a date and emit the event when Enter key is pressed. This behavior was added when arrow key controls were implemented, however, since then it has been changed such that arrow keys immediately emit the new value. So, the enter key behavior only has the effect of choosing the non-persisted date in other, unexpected scenarios, ex: after navigating to prev/next months or years.