### PR TITLE
Prevent mousedown on scrollbar from taking focus from input

### DIFF
--- a/packages/scrollbar/src/bar.js
+++ b/packages/scrollbar/src/bar.js
@@ -40,6 +40,8 @@ export default {
 
   methods: {
     clickThumbHandler(e) {
+      // Prevent mousedown on scrollbar from taking focus away from input
+      e.preventDefault();
       // prevent click event of right button
       if (e.ctrlKey || e.button === 2) {
         return;


### PR DESCRIPTION
This fixes this [pretty obvious bug](https://cognitoforms.visualstudio.com/Cognito%20Forms/_workitems/edit/17297), but also fixes a bug present in Element. [Clicking on the scrollbar doesn't appear to remove focus from input, but it does.](https://codepen.io/tylertrotter/pen/KKzRmYm)

