### PR TITLE
DatePicker: Emit "visible-change" event

### DIFF
--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -418,6 +418,7 @@ export default {
   watch: {
     pickerVisible(val) {
       if (this.readonly || this.pickerDisabled) return;
+      this.$emit('visible-change', val);
       if (val) {
         this.showPicker();
         this.valueOnOpen = Array.isArray(this.value) ? [...this.value] : this.value;


### PR DESCRIPTION
Emit a 'visible-change' event when date picker is hidden/shown. This is analogous to the `<el-select>` component's event.