### PR TITLE
Add class to indicate which side the select menu is on

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="el-select"
-    :class="[selectSize ? 'el-select--' + selectSize : '']"
+    :class="[selectSize ? 'el-select--' + selectSize : '', 'el-select--dropdown-' + popperPlacement]"
     @click="handleContainerClick"
     v-clickoutside="handleClickOutside">
     <div
@@ -119,6 +119,7 @@
       @after-leave="doDestroy">
       <el-select-menu
         ref="popper"
+        @placement="handlePlacement"
         :append-to-body="popperAppendToBody"
         v-show="visible && emptyText !== false">
         <el-scrollbar
@@ -351,7 +352,8 @@
         menuVisibleOnFocus: false,
         isOnComposition: false,
         isSilentBlur: false,
-        valueOnMenuOpen: ''
+        valueOnMenuOpen: '',
+        popperPlacement: 'bottom'
       };
     },
 
@@ -906,6 +908,10 @@
         } else {
           return getValueByPath(item.value, this.valueKey);
         }
+      },
+
+      handlePlacement(placement) {
+        this.popperPlacement = placement;
       }
     },
 

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -119,7 +119,7 @@
       @after-leave="doDestroy">
       <el-select-menu
         ref="popper"
-        @placement="handlePlacement"
+        @placement-change="handlePlacementChange"
         :append-to-body="popperAppendToBody"
         v-show="visible && emptyText !== false">
         <el-scrollbar
@@ -910,7 +910,7 @@
         }
       },
 
-      handlePlacement(placement) {
+      handlePlacementChange(placement) {
         this.popperPlacement = placement;
       }
     },

--- a/src/utils/vue-popper.js
+++ b/src/utils/vue-popper.js
@@ -151,7 +151,7 @@ export default {
         right: 'left'
       };
       let placement = this.popperJS._popper.getAttribute('x-placement').split('-')[0];
-      this.$emit('placement', placement);
+      this.$emit('placement-change', placement);
       let origin = placementMap[placement];
       this.popperJS._popper.style.transformOrigin = typeof this.transformOrigin === 'string'
         ? this.transformOrigin

--- a/src/utils/vue-popper.js
+++ b/src/utils/vue-popper.js
@@ -151,6 +151,7 @@ export default {
         right: 'left'
       };
       let placement = this.popperJS._popper.getAttribute('x-placement').split('-')[0];
+      this.$emit('placement', placement);
       let origin = placementMap[placement];
       this.popperJS._popper.style.transformOrigin = typeof this.transformOrigin === 'string'
         ? this.transformOrigin


### PR DESCRIPTION
Add a class to indicate if the select menu is on the top or the bottom of the select. This will be useful to sharpen the corners of the select that meet the sharpened corners of the menu on Rounded themes.

![image](https://user-images.githubusercontent.com/4097146/94154552-00a4ee80-fe4c-11ea-804a-90857a9bfe5d.png)
