### PR TITLE
Hovered select option gets selected on tab away

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -543,7 +543,7 @@
         this.visible = false;
       },
 
-      handleTabKey(e) { 
+      handleTabKey(e) {
         if (this.allowCreate) {
           this.handleOptionSelect(this.getMatchingOption());
         } else if (this.query.length > 0 && this.query !== this.selected.currentValue) {

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -517,7 +517,6 @@
         if (this.defaultFirstOption && (this.filterable || this.remote) && this.filteredOptionsCount) {
           this.checkDefaultFirstOption();
         }
-        this.$emit('queryChange', this.filteredOptionsCount);
       },
 
       handleUpArrowKey(e) {
@@ -544,13 +543,10 @@
         this.visible = false;
       },
 
-      handleTabKey(e) {
-        if (this.visible) {
-          e.preventDefault();
-        }
+      handleTabKey(e) { 
         if (this.allowCreate) {
           this.handleOptionSelect(this.getMatchingOption());
-        } else if (this.filteredOptionsCount === 1) {
+        } else if (this.query.length > 0 && this.query !== this.selected.currentValue) {
           this.handleOptionSelect(this.getFirstVisibleOption());
         }
         this.visible = false;

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -547,7 +547,6 @@
         if (this.visible) {
           e.preventDefault();
         }
-        this.selectOption(e);
         this.visible = false;
       },
 

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -517,6 +517,7 @@
         if (this.defaultFirstOption && (this.filterable || this.remote) && this.filteredOptionsCount) {
           this.checkDefaultFirstOption();
         }
+        this.$emit('queryChange', this.filteredOptionsCount);
       },
 
       handleUpArrowKey(e) {
@@ -547,7 +548,28 @@
         if (this.visible) {
           e.preventDefault();
         }
+        if (this.allowCreate) {
+          this.handleOptionSelect(this.getMatchingOption());
+        } else if (this.filteredOptionsCount === 1) {
+          this.handleOptionSelect(this.getFirstVisibleOption());
+        }
         this.visible = false;
+      },
+
+      getFirstVisibleOption() {
+        for (let i = 0; i < this.options.length; i++) {
+          if (this.options[i].visible) {
+            return this.options[i];
+          }
+        }
+      },
+
+      getMatchingOption() {
+        for (let i = 0; i < this.options.length; i++) {
+          if (this.options[i].currentValue === this.query) {
+            return this.options[i];
+          }
+        }
       },
 
       handleSpaceKey(e) {


### PR DESCRIPTION
It seems to me that PRs #30 and #37 are trying to accomplish the same thing in slightly different ways and in combination they caused the [second part of the bug Jamie slacked about last evening](https://cognitoforms.visualstudio.com/Cognito%20Forms/_workitems/edit/17534). #30 makes selections as soon as the arrow keys are pressed making selecting on tab not necessary.