### PR TITLE
compare query to label instead of value of select option when tabbing away

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -548,7 +548,7 @@
       handleTabKey(e) {
         if (this.allowCreate) {
           this.handleOptionSelect(this.getMatchingOption());
-        } else if (this.query.length > 0 && this.query !== this.selected.currentValue) {
+        } else if (this.query.length > 0 && this.query !== this.selected.currentLabel) {
           this.handleOptionSelect(this.getFirstVisibleOption());
         }
         this.visible = false;


### PR DESCRIPTION
The `query` represents the value of the text input, and should be compared to the visible text (label) of the select options. Comparing the `query` to `this.selected.currentValue` results in the highlighted option not being selected when tabbing away while the picker is open _if the option label is not the same as its value._