### PR TITLE
Prevent user CSSfrom interfering with textarea height measurement

### DIFF
--- a/packages/input/src/calcTextareaHeight.js
+++ b/packages/input/src/calcTextareaHeight.js
@@ -2,6 +2,8 @@ let hiddenTextarea;
 
 const HIDDEN_STYLE = `
   height:0 !important;
+  min-height:0 !important;
+  max-height:0 !important;
   visibility:hidden !important;
   overflow:hidden !important;
   position:absolute !important;
@@ -57,7 +59,7 @@ export default function calcTextareaHeight(
 ) {
   if (!hiddenTextarea) {
     hiddenTextarea = document.createElement('textarea');
-    document.body.appendChild(hiddenTextarea);
+    targetElement.parentElement.appendChild(hiddenTextarea);
   }
 
   let {


### PR DESCRIPTION
Setting min-height and max-height to zero is the main fix. The code already copied each style from the target textarea to the hidden textarea with JS so being in the same container shouldn't be necessary, but it does seem to make more sense to keep it in the form.