### PR TITLE
Fix "enter" after filtering and a console error when tabbing through a select

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -485,6 +485,7 @@
         }
       },
       handleQueryChange(val) {
+        this.query = val;
         if (this.previousQuery === val || this.isOnComposition) return;
         if (
           this.previousQuery === null &&
@@ -908,7 +909,7 @@
         if (hasCreated) return;
         for (let i = 0; i !== this.options.length; ++i) {
           const option = this.options[i];
-          if (this.query || this.alternativeFilter) {
+          if (this.query) {
             // highlight first options that passes the filter
             if (!option.disabled && !option.groupDisabled && option.visible) {
               this.hoverIndex = i;


### PR DESCRIPTION
Fix for "enter" - handle it the same as a query when an option is selected, so the option gets highlighted.
Fix for console error - do not handle null/undefined options