### PR TITLE
Multi select prevent close on option click

### DIFF
--- a/packages/select/src/option.vue
+++ b/packages/select/src/option.vue
@@ -7,11 +7,13 @@
     role="option"
     :id="select.id ? `${select.id}-option-${value}` : null"
     :aria-selected="itemSelected ? 'true' : 'false'"
-    :class="{
+    :class="[{
       'selected': itemSelected,
       'is-disabled': disabled || groupDisabled || limitReached,
-      'hover': hover
-    }">
+      'hover': hover,
+    },
+    customClass]"
+    >
     <slot>
       <span>{{ currentLabel }}</span>
     </slot>
@@ -40,6 +42,10 @@
       disabled: {
         type: Boolean,
         default: false
+      },
+      customClass: {
+        type: String,
+        default: ''
       }
     },
 

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -14,6 +14,7 @@
           :closable="!selectDisabled"
           :size="collapseTagSize"
           :hit="selected[0].hitState"
+          :class="selected[0].customClass"
           type="info"
           @close="deleteTag($event, selected[0])"
           disable-transitions>
@@ -35,6 +36,7 @@
           :closable="!selectDisabled"
           :size="collapseTagSize"
           :hit="item.hitState"
+          :class="item.customClass"
           type="info"
           @close="deleteTag($event, item)"
           disable-transitions>

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -955,8 +955,10 @@
         this.handleQueryChange(e.target.value);
       });
 
+      if (!this.multiple) {
+        this.$on('handleOptionClick', this.handleClose);
+      }
       this.$on('handleOptionClick', this.handleOptionSelect);
-      this.$on('handleOptionClick', this.handleClose);
       this.$on('setSelected', this.setSelected);
     },
 


### PR DESCRIPTION
New functionality, added a `customClass` prop to options and reference it when rendering tags for selected values when using a multi-select.

Fix a bug with multi select closing when selecting an option
