### PR TITLE
Base showNewOption on value instead of label

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -238,7 +238,7 @@
 
       showNewOption() {
         let hasExistingOption = this.options.filter(option => !option.created)
-          .some(option => option.currentLabel === this.query);
+          .some(option => option.currentValue === this.query);
         return this.filterable && this.allowCreate && this.query !== '' && !hasExistingOption;
       },
 


### PR DESCRIPTION
When trying to create a custom value if that value matches the label of another option you do not get a new option making it impossible to input that value. Basing `showNewOption` on value instead of label fixes this.