### PR TITLE
Add or remove 'handleOptionClick' event listener when multiple changes

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -476,6 +476,17 @@
         if (this.defaultFirstOption && (this.filterable || this.remote) && this.filteredOptionsCount) {
           this.checkDefaultFirstOption();
         }
+      },
+
+      multiple: {
+        immediate: true,
+        handler(val) {
+          if (val) {
+            this.$off('handleOptionClick', this.handleClose);
+          } else {
+            this.$on('handleOptionClick', this.handleClose);
+          }
+        }
       }
     },
 
@@ -962,9 +973,6 @@
       });
 
       this.$on('handleOptionClick', this.handleOptionSelect);
-      if (!this.multiple) {
-        this.$on('handleOptionClick', this.handleClose);
-      }
       this.$on('setSelected', this.setSelected);
     },
 


### PR DESCRIPTION
If the select is created with `multiple = false`  and then later turned to `true` the dropdown would hide after selecting a value even if `multiple = true` and the opposite would be true if the select was created with `multiple = true`.