### PR TITLE
clear selectedLabel when multiple prop is enabled

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -483,6 +483,8 @@
         handler(val) {
           if (val) {
             this.$off('handleOptionClick', this.handleClose);
+            // selectedLabel is really only a concept for single select mode
+            this.selectedLabel = '';
           } else {
             this.$on('handleOptionClick', this.handleClose);
           }

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -487,6 +487,8 @@
             this.selectedLabel = '';
           } else {
             this.$on('handleOptionClick', this.handleClose);
+            let option = this.getOption(this.value);
+            this.selectedLabel = option ? option.currentLabel : '';
           }
         }
       }


### PR DESCRIPTION
Since `selectedLabel` is only used for single select mode, make sure it is cleared out if the `multiple` prop is changed to `true`. Prior to this fix, the input could appear to have a value when the select actually had no values.