### PR TITLE
MultiSelect: Prevent endless height resizing

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -805,10 +805,11 @@
           let input = [].filter.call(inputChildNodes, item => item.tagName === 'INPUT')[0];
           const tags = this.$refs.tags;
           const sizeInMap = this.initialInputHeight || 40;
+          const tagsHeight = tags ? tags.getBoundingClientRect().height : 0;
           input.style.height = this.selected.length === 0
             ? sizeInMap + 'px'
             : Math.max(
-              tags ? (tags.clientHeight + (tags.clientHeight > sizeInMap ? 6 : 0)) : 0,
+              tags ? (tagsHeight + (tagsHeight > sizeInMap ? 6 : 0)) : 0,
               sizeInMap
             ) + 'px';
           if (this.visible && this.emptyText !== false) {


### PR DESCRIPTION
Switched to getBoundingClientRect() rather than clientHeight to prevent height rounding issues, which were triggering an endless resize loop.