### PR TITLE
Adding dropdown icon slot to Dropdown.vue for split-button dropdowns

### DIFF
--- a/packages/dropdown/src/dropdown.vue
+++ b/packages/dropdown/src/dropdown.vue
@@ -257,6 +257,8 @@
         hide();
       };
 
+      let dropdownButton = this.$slots.dropdownIcon ? this.$slots.dropdownIcon : <i class="el-dropdown__icon el-icon-arrow-down"></i>;
+
       let triggerElm = !splitButton
         ? this.$slots.default
         : (<el-button-group>
@@ -264,7 +266,7 @@
             {this.$slots.default}
           </el-button>
           <el-button ref="trigger" type={type} size={dropdownSize} class="el-dropdown__caret-button">
-            <i class="el-dropdown__icon el-icon-arrow-down"></i>
+            {dropdownButton}
           </el-button>
         </el-button-group>);
 


### PR DESCRIPTION
Adding a slot to allow for customizing the dropdown button icon for split-button dropdowns