### PR TITLE
reset multiselect input height on close

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -495,8 +495,11 @@
           this.valueOnMenuOpen = this.value;
         } else {
           this.emitChange(this.value);
-        }
 
+          if (this.multiple) {
+            this.resetInputHeight();
+          }
+        }
       },
 
       options() {


### PR DESCRIPTION
If multiple choices were selected and the user had an invalid query which caused the input to increase its height, pressing the enter key or blurring the input would close the dropdown and leave the input too tall. This change ensures the input height is reset after the dropdown is closed.