### PR TITLE
Calculate the minheight of text areas always 

### DIFF
--- a/packages/input/src/calcTextareaHeight.js
+++ b/packages/input/src/calcTextareaHeight.js
@@ -103,6 +103,7 @@ export default function calcTextareaHeight(
   }
 
   result.height = `${ height }px`;
+  result.minHeight = `${ height }px`;
   hiddenTextarea.parentNode && hiddenTextarea.parentNode.removeChild(hiddenTextarea);
   hiddenTextarea = null;
   return result;


### PR DESCRIPTION
This sets the minheight of the input field at its creation, so the user cannot make it smaller than this initial value. Solution to resize issue for text areas inside of tables (25942)