### PR TITLE
only check default when there is a query

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -514,7 +514,7 @@
         if ([].indexOf.call(inputs, document.activeElement) === -1) {
           this.setSelected();
         }
-        if (this.defaultFirstOption && (this.filterable || this.remote) && this.filteredOptionsCount) {
+        if (this.defaultFirstOption && (this.filterable || this.remote) && this.filteredOptionsCount && this.textLength > 0) {
           this.checkDefaultFirstOption();
         }
       },


### PR DESCRIPTION
This allows us to leave `default-first-option` as true and still fix the double down button press