### PR TITLE
Allow user to input time between steps

### DIFF
--- a/packages/date-picker/src/panel/time-select.vue
+++ b/packages/date-picker/src/panel/time-select.vue
@@ -147,7 +147,9 @@
       },
 
       isValidValue(date) {
-        return this.items.filter(item => !item.disabled).map(item => item.value).indexOf(date) !== -1;
+        var isValidTime = /^([0-1]?[0-9]|2[0-4]):([0-5][0-9])(:[0-5][0-9])?$/.test(value);
+
+        return this.items.filter(item => !item.disabled).map(item => item.value).indexOf(date) !== -1 || isValidTime;
       },
 
       handleKeydown(event) {

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -953,8 +953,11 @@ export default {
       if (!this.picker) {
         this.mountPicker();
       }
-      if (this.picker.isValidValue) {
-        return value && this.picker.isValidValue(value);
+
+      var isValidValue = /^([0-1]?[0-9]|2[0-4]):([0-5][0-9])(:[0-5][0-9])?$/.test(value);
+
+      if (this.picker.isValidValue || isValidValue) {
+        return value && (this.picker.isValidValue(value) || isValidValue);
       } else {
         return true;
       }

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -954,10 +954,8 @@ export default {
         this.mountPicker();
       }
 
-      var isValidValue = /^([0-1]?[0-9]|2[0-4]):([0-5][0-9])(:[0-5][0-9])?$/.test(value);
-
-      if (this.picker.isValidValue || isValidValue) {
-        return value && (this.picker.isValidValue(value) || isValidValue);
+      if (this.picker.isValidValue) {
+        return value && this.picker.isValidValue(value);
       } else {
         return true;
       }

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -953,7 +953,6 @@ export default {
       if (!this.picker) {
         this.mountPicker();
       }
-
       if (this.picker.isValidValue) {
         return value && this.picker.isValidValue(value);
       } else {


### PR DESCRIPTION
We want to use element's TimeSelect component for the limit availability of public links with a date range (to replace Limit Availability settings), we need to be able to type out the time even if it's not represented by the steps of the dropdown. However, we need to ensure the user is entering a valid time. 

Using a regex and altering the return value of the Picker component's isValidValue method.
