### PR TITLE
Change aria-checked value to strings rather than booleans

### DIFF
--- a/packages/checkbox/src/checkbox-button.vue
+++ b/packages/checkbox/src/checkbox-button.vue
@@ -8,7 +8,7 @@
         { 'is-focus': focus },
       ]"
     role="checkbox"
-    :aria-checked="isChecked"
+    :aria-checked="isChecked ? 'true' : 'false'"
     :aria-disabled="isDisabled"
     >
     <input

--- a/packages/checkbox/src/checkbox.vue
+++ b/packages/checkbox/src/checkbox.vue
@@ -18,7 +18,7 @@
       }"
       :tabindex="indeterminate ? 0 : false"
       :role="indeterminate ? 'checkbox' : false"
-      :aria-checked="indeterminate ? 'mixed' : false"
+      :aria-checked="indeterminate ? 'mixed' : 'false'"
     >
       <span class="el-checkbox__inner"></span>
       <input

--- a/packages/radio/src/radio-button.vue
+++ b/packages/radio/src/radio-button.vue
@@ -8,7 +8,7 @@
       { 'is-focus': focus }
     ]"
     role="radio"
-    :aria-checked="value === label"
+    :aria-checked="value === label ? 'true' : 'false'"
     :aria-disabled="isDisabled"
     :tabindex="tabIndex"
     @keydown.space.stop.prevent="value = isDisabled ? value : label"

--- a/packages/radio/src/radio.vue
+++ b/packages/radio/src/radio.vue
@@ -9,7 +9,7 @@
       { 'is-checked': model === label }
     ]"
     role="radio"
-    :aria-checked="model === label"
+    :aria-checked="model === label ? 'true' : 'false'"
     :aria-disabled="isDisabled"
     :tabindex="tabIndex"
     @keydown.space.stop.prevent="model = isDisabled ? model : label"

--- a/packages/tree/src/tree-node.vue
+++ b/packages/tree/src/tree-node.vue
@@ -15,7 +15,7 @@
     tabindex="-1"
     :aria-expanded="expanded"
     :aria-disabled="node.disabled"
-    :aria-checked="node.checked"
+    :aria-checked="node.checked ? 'true' : 'false'"
     :draggable="tree.draggable"
     @dragstart.stop="handleDragStart"
     @dragover.stop="handleDragOver"


### PR DESCRIPTION
Vue does not add aria-checked when the boolean value is false, so this PR converts it to a string to ensure aria-checked is always added.