### PR TITLE
Revert aria checked in checkbox.vue

### DIFF
--- a/packages/checkbox/src/checkbox.vue
+++ b/packages/checkbox/src/checkbox.vue
@@ -18,7 +18,7 @@
       }"
       :tabindex="indeterminate ? 0 : false"
       :role="indeterminate ? 'checkbox' : false"
-      :aria-checked="indeterminate ? 'mixed' : 'false'"
+      :aria-checked="indeterminate ? 'mixed' : false"
     >
       <span class="el-checkbox__inner"></span>
       <input


### PR DESCRIPTION
The change in Checkbox.vue is making checkboxes have aria-checked="false" in most cases, which we do not want. This PR is to revert this change that caused it.