### PR TITLE
Add new behavior to autocomplete component

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -18,7 +18,7 @@
       @keydown.up.native.prevent="highlight(highlightedIndex - 1)"
       @keydown.down.native.prevent="highlight(highlightedIndex + 1)"
       @keydown.enter.native="handleKeyEnter"
-      @keydown.native.tab="close"
+      @keydown.native.tab="handleKeyEnter"
     >
       <template slot="prepend" v-if="$slots.prepend">
         <slot name="prepend"></slot>

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -148,7 +148,7 @@
         loading: false,
         highlightedIndex: -1,
         suggestionDisabled: false,
-        selected: false
+        handledSelection: false
       };
     },
     computed: {
@@ -198,7 +198,7 @@
       },
       handleInput(value) {
         this.$emit('input', value);
-        this.selected = false;
+        this.handledSelection = false;
         if (!this.blurOnSelect) { this.$refs.input.ignoreNextBlur(true); }
         this.suggestionDisabled = false;
         if (!this.triggerOnFocus && !value) {
@@ -219,7 +219,6 @@
         }
       },
       handleBlur(event) {
-        this.activated = false;
         this.$emit('blur', event);
       },
       handleClear() {
@@ -228,8 +227,8 @@
       },
       close(e) {
         this.activated = false;
-        if (!this.selected && !this.blurOnSelect) {
-          this.selected = true;
+        if (!this.handledSelection && !this.blurOnSelect) {
+          this.handledSelection = true;
           this.$refs.input.blur();
         }
       },
@@ -247,7 +246,7 @@
         }
       },
       select(item) {
-        this.selected = true;
+        this.handledSelection = true;
         if (this.fillOnSelect) { this.$emit('input', item[this.valueKey]); }
         this.$emit('select', item);
         this.$nextTick(_ => {

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -228,13 +228,13 @@
       },
       close(e) {
         this.activated = false;
-        if (!this.selected) {
+        if (!this.selected && !this.blurOnSelect) {
           this.selected = true;
           this.$refs.input.blur();
         }
       },
       handleKeyEnter(e) {
-        if (this.blurOnSelect) { this.$refs.input.ignoreNextBlur(false); }
+        if (!this.blurOnSelect) { this.$refs.input.ignoreNextBlur(false); }
         if (this.suggestionVisible && this.highlightedIndex >= 0 && this.highlightedIndex < this.suggestions.length) {
           e.preventDefault();
           this.select(this.suggestions[this.highlightedIndex]);

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -237,7 +237,7 @@
       },
       handleKeyTab(e) {
         if (this.tabSelectsSuggestion) {
-          this.select(this.suggestions[this.highlightedIndex]);
+          this.handleKeyEnter(e);
         } else {
           if (!this.blurOnSelect) { this.$refs.input.ignoreNextBlur(false); }
           this.close(e);

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -197,7 +197,7 @@
       },
       handleInput(value) {
         this.$emit('input', value);
-        this.$refs.input.ignoreNextBlur(true);
+        if (this.blurOnSelect) { this.$refs.input.ignoreNextBlur(true); }
         this.suggestionDisabled = false;
         if (!this.triggerOnFocus && !value) {
           this.suggestionDisabled = true;
@@ -227,7 +227,7 @@
         this.activated = false;
       },
       handleKeyEnter(e) {
-        this.$refs.input.ignoreNextBlur(false);
+        if (this.blurOnSelect) { this.$refs.input.ignoreNextBlur(false); }
         if (this.suggestionVisible && this.highlightedIndex >= 0 && this.highlightedIndex < this.suggestions.length) {
           e.preventDefault();
           this.select(this.suggestions[this.highlightedIndex]);
@@ -240,7 +240,7 @@
         }
       },
       select(item) {
-        if (this.fillOnSelected) {
+        if (this.fillOnSelect) {
           this.$emit('input', item[this.valueKey]);
         }
         this.$emit('select', item);

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -19,7 +19,6 @@
       @keydown.down.native.prevent="highlight(highlightedIndex + 1)"
       @keydown.enter.native="handleKeyEnter"
       @keydown.native.tab="close"
-      @keydown.tab="close"
     >
       <template slot="prepend" v-if="$slots.prepend">
         <slot name="prepend"></slot>
@@ -220,6 +219,7 @@
         }
       },
       handleBlur(event) {
+        this.activated = false;
         this.$emit('blur', event);
       },
       handleClear() {

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -19,6 +19,7 @@
       @keydown.down.native.prevent="highlight(highlightedIndex + 1)"
       @keydown.enter.native="handleKeyEnter"
       @keydown.native.tab="close"
+      @keydown.tab="close"
     >
       <template slot="prepend" v-if="$slots.prepend">
         <slot name="prepend"></slot>
@@ -138,7 +139,7 @@
       },
       blurOnSelect: {
         type: Boolean,
-        default: false
+        default: true
       }
     },
     data() {
@@ -147,7 +148,8 @@
         suggestions: [],
         loading: false,
         highlightedIndex: -1,
-        suggestionDisabled: false
+        suggestionDisabled: false,
+        selected: false
       };
     },
     computed: {
@@ -197,7 +199,8 @@
       },
       handleInput(value) {
         this.$emit('input', value);
-        if (this.blurOnSelect) { this.$refs.input.ignoreNextBlur(true); }
+        this.selected = false;
+        if (!this.blurOnSelect) { this.$refs.input.ignoreNextBlur(true); }
         this.suggestionDisabled = false;
         if (!this.triggerOnFocus && !value) {
           this.suggestionDisabled = true;
@@ -225,6 +228,10 @@
       },
       close(e) {
         this.activated = false;
+        if (!this.selected) {
+          this.selected = true;
+          this.$refs.input.blur();
+        }
       },
       handleKeyEnter(e) {
         if (this.blurOnSelect) { this.$refs.input.ignoreNextBlur(false); }
@@ -240,9 +247,8 @@
         }
       },
       select(item) {
-        if (this.fillOnSelect) {
-          this.$emit('input', item[this.valueKey]);
-        }
+        this.selected = true;
+        if (this.fillOnSelect) { this.$emit('input', item[this.valueKey]); }
         this.$emit('select', item);
         this.$nextTick(_ => {
           this.suggestions = [];

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -18,7 +18,7 @@
       @keydown.up.native.prevent="highlight(highlightedIndex - 1)"
       @keydown.down.native.prevent="highlight(highlightedIndex + 1)"
       @keydown.enter.native="handleKeyEnter"
-      @keydown.native.tab="handleKeyEnter"
+      @keydown.native.tab="handleKeyTab"
     >
       <template slot="prepend" v-if="$slots.prepend">
         <slot name="prepend"></slot>
@@ -139,6 +139,10 @@
       blurOnSelect: {
         type: Boolean,
         default: true
+      },
+      tabSelectsSuggestion: {
+        type: Boolean,
+        default: false
       }
     },
     data() {
@@ -199,8 +203,8 @@
       handleInput(value) {
         this.$emit('input', value);
         this.handledSelection = false;
-        if (!this.blurOnSelect) { this.$refs.input.ignoreNextBlur(true); }
         this.suggestionDisabled = false;
+        if (!this.blurOnSelect) { this.$refs.input.ignoreNextBlur(true); }
         if (!this.triggerOnFocus && !value) {
           this.suggestionDisabled = true;
           this.suggestions = [];
@@ -228,8 +232,15 @@
       close(e) {
         this.activated = false;
         if (!this.handledSelection && !this.blurOnSelect) {
-          this.handledSelection = true;
           this.$refs.input.blur();
+        }
+      },
+      handleKeyTab(e) {
+        if (this.tabSelectsSuggestion) {
+          this.select(this.suggestions[this.highlightedIndex]);
+        } else {
+          if (!this.blurOnSelect) { this.$refs.input.ignoreNextBlur(false); }
+          this.close(e);
         }
       },
       handleKeyEnter(e) {

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -10,7 +10,6 @@
     <el-input
       ref="input"
       v-bind="[$props, $attrs]"
-      :disable-blur-event="disableInputBlur"
       @input="handleInput"
       @change="handleChange"
       @focus="handleFocus"
@@ -148,8 +147,7 @@
         suggestions: [],
         loading: false,
         highlightedIndex: -1,
-        suggestionDisabled: false,
-        disableInputBlur: false
+        suggestionDisabled: false
       };
     },
     computed: {
@@ -199,6 +197,7 @@
       },
       handleInput(value) {
         this.$emit('input', value);
+        this.$refs.input.ignoreNextBlur(true);
         this.suggestionDisabled = false;
         if (!this.triggerOnFocus && !value) {
           this.suggestionDisabled = true;
@@ -228,6 +227,7 @@
         this.activated = false;
       },
       handleKeyEnter(e) {
+        this.$refs.input.ignoreNextBlur(false);
         if (this.suggestionVisible && this.highlightedIndex >= 0 && this.highlightedIndex < this.suggestions.length) {
           e.preventDefault();
           this.select(this.suggestions[this.highlightedIndex]);
@@ -240,7 +240,6 @@
         }
       },
       select(item) {
-        this.disableInputBlur = true;
         if (this.fillOnSelected) {
           this.$emit('input', item[this.valueKey]);
         }
@@ -248,7 +247,6 @@
         this.$nextTick(_ => {
           this.suggestions = [];
           this.highlightedIndex = -1;
-          this.disableInputBlur = false;
         });
       },
       highlight(index) {

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -10,6 +10,7 @@
     <el-input
       ref="input"
       v-bind="[$props, $attrs]"
+      :disable-blur-event="disableInputBlur"
       @input="handleInput"
       @change="handleChange"
       @focus="handleFocus"
@@ -131,6 +132,18 @@
       highlightFirstItem: {
         type: Boolean,
         default: false
+      },
+      fillOnSelect: {
+        type: Boolean,
+        default: true
+      },
+      blurOnSelect: {
+        type: Boolean,
+        default: false
+      },
+      clearOnSelect: {
+        type: Boolean,
+        default: false
       }
     },
     data() {
@@ -139,7 +152,8 @@
         suggestions: [],
         loading: false,
         highlightedIndex: -1,
-        suggestionDisabled: false
+        suggestionDisabled: false,
+        disableInputBlur: false
       };
     },
     computed: {
@@ -230,11 +244,18 @@
         }
       },
       select(item) {
-        this.$emit('input', item[this.valueKey]);
+        this.disableInputBlur = true;
+        if (this.fillOnSelected) {
+          this.$emit('input', item[this.valueKey]);
+        }
+        if (this.clearOnSelected) {
+          this.$emit('input', '');
+        }
         this.$emit('select', item);
         this.$nextTick(_ => {
           this.suggestions = [];
           this.highlightedIndex = -1;
+          this.disableInputBlur = false;
         });
       },
       highlight(index) {

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -236,8 +236,8 @@
         }
       },
       handleKeyTab(e) {
-        if (this.tabSelectsSuggestion) {
-          this.handleKeyEnter(e);
+        if (this.tabSelectsSuggestion && this.highlightedIndex >= 0 && this.highlightedIndex < this.suggestions.length) {
+          this.select(this.suggestions[this.highlightedIndex]);
         } else {
           if (!this.blurOnSelect) { this.$refs.input.ignoreNextBlur(false); }
           this.close(e);

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -140,10 +140,6 @@
       blurOnSelect: {
         type: Boolean,
         default: false
-      },
-      clearOnSelect: {
-        type: Boolean,
-        default: false
       }
     },
     data() {
@@ -247,9 +243,6 @@
         this.disableInputBlur = true;
         if (this.fillOnSelected) {
           this.$emit('input', item[this.valueKey]);
-        }
-        if (this.clearOnSelected) {
-          this.$emit('input', '');
         }
         this.$emit('select', item);
         this.$nextTick(_ => {

--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -16,7 +16,7 @@
     @mouseleave="hovering = false"
   >
     <template v-if="type !== 'textarea'">
-      <!-- 前置元素 -->
+       <!-- Prepend element -->
       <div class="el-input-group__prepend" v-if="$slots.prepend">
         <slot name="prepend"></slot>
       </div>
@@ -39,7 +39,7 @@
         @change="handleChange"
         :aria-label="label"
       >
-      <!-- 前置内容 -->
+      <!-- Prefix content -->
       <span class="el-input__prefix" v-if="$slots.prefix || prefixIcon">
         <slot name="prefix"></slot>
         <i class="el-input__icon"
@@ -47,7 +47,7 @@
            :class="prefixIcon">
         </i>
       </span>
-      <!-- 后置内容 -->
+      <!-- Suffix content -->
       <span
         class="el-input__suffix"
         v-if="getSuffixVisible()">
@@ -79,7 +79,7 @@
           :class="['el-input__validateIcon', validateIcon]">
         </i>
       </span>
-      <!-- 后置元素 -->
+      <!-- Append element -->
       <div class="el-input-group__append" v-if="$slots.append">
         <slot name="append"></slot>
       </div>
@@ -189,9 +189,12 @@
         type: Boolean,
         default: false
       },
-      tabindex: String
+      tabindex: String,
+      disableBlurEvent: {
+        type: Boolean,
+        default: false
+      }
     },
-
     computed: {
       _elFormItemSize() {
         return (this.elFormItem || {}).elFormItemSize;
@@ -303,6 +306,10 @@
         };
       },
       handleBlur(event) {
+        if (this.disableBlurEvent) {
+          event.preventDefault();
+          this.$refs.input.focus();
+        }
         this.focused = false;
         this.$emit('blur', event);
         if (this.validateEvent) {

--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -192,7 +192,7 @@
       },
       tabindex: String
     },
-    
+
     computed: {
       _elFormItemSize() {
         return (this.elFormItem || {}).elFormItemSize;

--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -192,6 +192,7 @@
       },
       tabindex: String
     },
+    
     computed: {
       _elFormItemSize() {
         return (this.elFormItem || {}).elFormItemSize;

--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -309,7 +309,7 @@
       handleBlur(event) {
         if (this.ignoreBlur) {
           this.ignoreBlur = false;
-          event.preventDefault();
+          this.$refs.input.focus();
           return;
         }
         this.focused = false;

--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -138,7 +138,8 @@
         hovering: false,
         focused: false,
         isComposing: false,
-        passwordVisible: false
+        passwordVisible: false,
+        ignoreBlur: false
       };
     },
 
@@ -189,11 +190,7 @@
         type: Boolean,
         default: false
       },
-      tabindex: String,
-      disableBlurEvent: {
-        type: Boolean,
-        default: false
-      }
+      tabindex: String
     },
     computed: {
       _elFormItemSize() {
@@ -305,10 +302,14 @@
           }
         };
       },
+      ignoreNextBlur(state) {
+        this.ignoreBlur = state;
+      },
       handleBlur(event) {
-        if (this.disableBlurEvent) {
+        if (this.ignoreBlur) {
+          this.ignoreBlur = false;
           event.preventDefault();
-          this.$refs.input.focus();
+          return;
         }
         this.focused = false;
         this.$emit('blur', event);

--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,7 @@ if (typeof window !== 'undefined' && window.Vue) {
 }
 
 export default {
-  version: '2.13.2',
+  version: '2.13.2-37',
   locale: locale.use,
   i18n: locale.i18n,
   install,

--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,7 @@ if (typeof window !== 'undefined' && window.Vue) {
 }
 
 export default {
-  version: '2.13.2-37',
+  version: '2.13.2',
   locale: locale.use,
   i18n: locale.i18n,
   install,


### PR DESCRIPTION
This PR adds fillOnSelected and blurOnSelect props to the autocomplete component.

1. fillOnSelected: Controls if the input field is automatically filled with the selected suggestion.
2. blurOnSelect: Determines whether the input field should lose focus after a selection.
3. Clicking tab does not dismiss the suggestion list.